### PR TITLE
DO NOT MERGE: Adjusting styles so that the container width is 1220px

### DIFF
--- a/src/app/components/hmcts-global-footer/hmcts-global-footer.component.html
+++ b/src/app/components/hmcts-global-footer/hmcts-global-footer.component.html
@@ -1,5 +1,5 @@
 <footer class="govuk-footer" role="contentinfo">
-  <div class="govuk-width-container ">
+  <div class="hmcts-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="hmcts-footer__heading">

--- a/src/app/components/hmcts-global-header/hmcts-global-header.component.html
+++ b/src/app/components/hmcts-global-header/hmcts-global-header.component.html
@@ -1,6 +1,6 @@
 <header class="hmcts-header" role="banner">
     <div class="hmcts-header__container">
-      <div class="govuk-width-container">
+      <div class="hmcts-width-container">
         <div class="hmcts-header__logo">
             <a class="hmcts-header__link" [routerLink]="'/'" [attr.aria-label]="serviceName.name" >{{serviceName.name}}</a>
         </div>

--- a/src/org-manager/containers/overview/org-overview.component.html
+++ b/src/org-manager/containers/overview/org-overview.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-width-container">
+<div class="hmcts-width-container">
 <main class="govuk-main-wrapper">
 <div *ngIf="(pendingOrgsCount$ | async) !== 0">
 <app-notification-banner-component>

--- a/src/shared/components/phase-banner/phase-banner.component.html
+++ b/src/shared/components/phase-banner/phase-banner.component.html
@@ -1,4 +1,4 @@
-<div class="govuk-width-container">
+<div class="hmcts-width-container">
     <div class="govuk-phase-banner">
         <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">
                 {{type}}


### PR DESCRIPTION
Works locally for Header, Footer and Page Content. But only tested on the first Page as could not logging. Once code freeze has been lifted, apply to other pages and test on an environment.