### PR TITLE
EUI-2515: Fix page content for deleting an "Active" organisation

### DIFF
--- a/src/org-manager/containers/delete-organisation-success/delete-organisation-success.component.html
+++ b/src/org-manager/containers/delete-organisation-success/delete-organisation-success.component.html
@@ -1,23 +1,27 @@
 <div class="hmcts-width-container">
-    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-                <div class="govuk-panel govuk-panel--confirmation">
-                    <h1 class="govuk-panel__title">
-                      {{orgForReview.name}} has been deleted
-                    </h1>
-                </div>
-                <h2 class="govuk-heading-m">What happens next</h2>
-                <p class="govuk-body">
-                  You should tell the pending organisation they’ve been deleted.
-                </p>
-                <p class="govuk-body">
-                  They’ve also been removed from your list of pending organisations.
-                </p>
-                <p class="govuk-body">
-                    <span text><a [routerLink]="['/']"> Go back to pending organisations</a></span>
-                </p>
-            </div>
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+          <h1 class="govuk-panel__title">
+            {{orgForReview.name}} has been deleted
+          </h1>
         </div>
-    </main>
+        <h2 class="govuk-heading-m">What happens next</h2>
+        <p class="govuk-body">
+          You should tell the {{ orgForReview.status==='PENDING' ? 'pending ' : '' }}organisation they've been deleted.
+        </p>
+        <p class="govuk-body">
+          They've also been removed from your list of {{ orgForReview.status==='PENDING' ? 'pending' : 'active' }} organisations.
+        </p>
+        <p class="govuk-body">
+          <span text>
+            <a [routerLink]="[orgForReview.status==='PENDING' ? '/' : '/active-organisation']">
+              Go back to {{ orgForReview.status==='PENDING' ? 'pending' : 'active' }} organisations
+            </a>
+          </span>
+        </p>
+      </div>
+    </div>
+  </main>
 </div>

--- a/src/org-manager/containers/delete-organisation/delete-organisation.component.html
+++ b/src/org-manager/containers/delete-organisation/delete-organisation.component.html
@@ -4,9 +4,10 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-xl">Delete this registration request?</h1>
-
           <ng-container *ngIf="orgForReview">
+            <h1 class="govuk-heading-xl">
+              Delete this {{ orgForReview.status==='PENDING' ? 'registration request' : 'organisation' }}?
+            </h1>
             <dl class="govuk-summary-list">
 
               <div class="govuk-summary-list__row">
@@ -50,10 +51,18 @@
 
               </div>
             </dl>
+            <div class="govuk-warning-text" *ngIf="orgForReview.status==='ACTIVE'">
+              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+              <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                Make sure you have the organisation's permission before deleting them.
+              </strong>
+            </div>
           </ng-container>
-          <button type="button" class="govuk-button" [disabled]="confirmButtonDisabled"
+          <button type="button" class="govuk-button" [class.govuk-button--warning]="orgForReview.status==='ACTIVE'"
+                  [disabled]="confirmButtonDisabled"
                   (click)="onDeleteOrganisationHandler(orgForReview)">
-            Confirm
+            {{ orgForReview.status==='PENDING' ? 'Confirm' : 'Delete organisation' }}
           </button>
         </div>
       </div>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2515

### Change description ###
Remove incorrect use of the word `pending` on the success page when deleting an `Active` organisation. Amend title, `Delete` button text and style, and add prescribed warning text on the confirmation page.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
