### PR TITLE
Move page titles from ngrx store to routes/ title service

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectName=rpx-xui-ao-webapp
 sonar.projectVersion=0.0.1
 sonar.sources=src/app
 sonar.exclusions= api/**, test/**, api/**/templates/**, src/public/**, src/environments/**, **/*.html, **/*.scss, src/app/app.references.ts, src/app/services/appInsightsWrapper.ts
-sonar.test.inclusions=src/app/**/*.spec.ts, src/app/*.spec.ts
+sonar.test.inclusions=**/*.spec.ts
 sonar.dynamicAnalysis=reuseReports
 
 client.sonar.ts.tslint.configPath=tslint.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,6 +8,6 @@ sonar.dynamicAnalysis=reuseReports
 
 client.sonar.ts.tslint.configPath=tslint.json
 client.sonar.ts.coverage.lcovReportPath=reports/tests/coverage/ng/lcov.info
-sonar.typescript.lcov.reportPaths=reports/tests/coverage/ng/lcov.info
+sonar.javascript.lcov.reportPaths=reports/tests/coverage/ng/lcov.info
 sonar.host.url=
 sonar.pullrequest.provider=GitHub

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,7 +5,7 @@ import { AuthGuard } from 'src/services/auth/auth.guard';
 import { NotAuthorisedComponent } from './components/not-authorised/not-authorised.component';
 import { RedirectComponent } from './containers';
 import { Routes } from '@angular/router';
-import {ServiceDownComponent} from './components/service-down/service-down.component';
+import { ServiceDownComponent } from './components/service-down/service-down.component';
 import { SignedOutComponent } from './components/signed-out/signed-out.component';
 
 export const ROUTES: Routes = [
@@ -19,7 +19,10 @@ export const ROUTES: Routes = [
     path: 'caseworker-details',
     canActivate: [AuthGuard, RoleGuard],
     loadChildren: '../caseworker-ref-data/caseworker-ref-data.module#CaseWorkerRefDataModule',
-    data: {needsRole: ['cwd-admin'], roleMatching: RoleMatching.ALL }
+    data: {
+      needsRole: ['cwd-admin'],
+      roleMatching: RoleMatching.ALL
+    }
   },
   {
     canActivate: [AuthGuard],
@@ -30,35 +33,59 @@ export const ROUTES: Routes = [
     path: 'organisation',
     canActivate: [AuthGuard, RoleGuard],
     loadChildren: '../org-manager/org-manager.module#OrgManagerModule',
-    data: {needsRole: ['prd-admin'], roleMatching: RoleMatching.ALL }
+    data: {
+      needsRole: ['prd-admin'],
+      roleMatching: RoleMatching.ALL
+    }
   },
   {
     path: 'cookies',
-    component: CookiePolicyComponent
+    component: CookiePolicyComponent,
+    data: {
+      title: 'cookies'
+    }
   },
   {
     path: 'privacy-policy',
-    component: PrivacyPolicyComponent
+    component: PrivacyPolicyComponent,
+    data: {
+      title: 'Privacy policy'
+    }
   },
   {
     path: 'terms-and-conditions',
-    component: TermsAndConditionsComponent
+    component: TermsAndConditionsComponent,
+    data: {
+      title: 'Terms and conditions'
+    }
   },
   {
     path: 'accessibility',
-    component: AccessibilityComponent
+    component: AccessibilityComponent,
+    data: {
+      title: 'Accessibility'
+    }
   },
   {
     path: 'service-down',
-    component: ServiceDownComponent
+    component: ServiceDownComponent,
+    data: {
+      title: 'Service down'
+    }
   },
-   {
+  {
     path: 'not-authorised',
-    component: NotAuthorisedComponent
+    component: NotAuthorisedComponent,
+    data: {
+      title: 'Not authorised'
+    }
   },
   {
     path: 'signed-out',
-    component: SignedOutComponent
+    component: SignedOutComponent,
+    data: {
+      title: 'Signed out'
+    }
   },
   {
     path: '**',

--- a/src/app/containers/app/app.component.html
+++ b/src/app/containers/app/app.component.html
@@ -1,4 +1,4 @@
-<title>{{title$ | async}}</title>
+<title>HMCTS Approve organisations</title>
 
 <app-header (navigate)="onNavigate($event)"></app-header>
 

--- a/src/app/containers/app/app.component.spec.ts
+++ b/src/app/containers/app/app.component.spec.ts
@@ -1,27 +1,30 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
+import { Title } from '@angular/platform-browser';
+import { RoutesRecognized } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ManageSessionServices, windowToken } from '@hmcts/rpx-xui-common-lib';
 import { combineReducers, Store, StoreModule } from '@ngrx/store';
 import { CookieService } from 'ngx-cookie';
 import { of } from 'rxjs';
 import { EnvironmentService } from 'src/app/services/environment.service';
-import {Logout, reducers} from 'src/app/store';
+import { Logout, reducers } from 'src/app/store';
 import * as fromRoot from '../../store';
 import { HeaderComponent } from '../header/header.component';
 import { AppComponent } from './app.component';
 
 
-const windowMock: Window = { gtag: () => {}} as any;
+const windowMock: Window = { gtag: () => { } } as any;
 const idleMockService = jasmine.createSpyObj('idleService', ['appStateChanges']);
 const environmentMockService = jasmine.createSpyObj('environmentService', ['getEnv$']);
 const cookieService = jasmine.createSpyObj('cookieSevice', ['getObject']);
+const titleService = jasmine.createSpyObj('titleService', ['setTitle']);
 
 describe('AppComponent', () => {
   let store: Store<fromRoot.State>;
   beforeEach(async(() => {
     environmentMockService.getEnv$.and.returnValue(of({}));
-    idleMockService.appStateChanges.and.returnValue(of({type: 'modal'}));
+    idleMockService.appStateChanges.and.returnValue(of({ type: 'modal' }));
     TestBed.configureTestingModule({
       declarations: [
         AppComponent,
@@ -41,8 +44,109 @@ describe('AppComponent', () => {
           provide: windowToken,
           useValue: windowMock
         },
-        { provide: ManageSessionServices, useValue: idleMockService},
-        { provide: EnvironmentService, useValue: environmentMockService},
+        { provide: ManageSessionServices, useValue: idleMockService },
+        { provide: EnvironmentService, useValue: environmentMockService },
+        { provide: CookieService, useValue: cookieService },
+        { provide: Title, useValue: titleService }
+      ],
+    }).compileComponents();
+    store = TestBed.get(Store);
+
+    spyOn(store, 'dispatch').and.callThrough();
+  }));
+
+  it('should create the app', async(() => {
+    const fixture = TestBed.createComponent(AppComponent);
+
+    const app = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+    expect(app).toBeTruthy();
+  }));
+
+  it('should dispatch a logout action', async(() => {
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    app.onNavigate('sign-out');
+    fixture.detectChanges();
+
+    expect(store.dispatch).toHaveBeenCalledWith(new Logout());
+
+  }));
+
+  it('should call the title service', () => {
+    let testRoute: RoutesRecognized;
+
+    testRoute = new RoutesRecognized(1, 'test', 'test', {
+      url: 'test',
+      root: {
+        firstChild: {
+          data: { title: 'Test' },
+          url: [],
+          params: {},
+          queryParams: {},
+          fragment: '',
+          outlet: '',
+          component: '',
+          routeConfig: {},
+          root: null,
+          parent: null,
+          firstChild: null,
+          children: [],
+          pathFromRoot: [],
+          paramMap: null,
+          queryParamMap: null
+        },
+        data: { title: 'Test' },
+        url: [],
+        params: {},
+        queryParams: {},
+        fragment: '',
+        outlet: '',
+        component: '',
+        routeConfig: {},
+        root: null,
+        parent: null,
+        children: [],
+        pathFromRoot: [],
+        paramMap: null,
+        queryParamMap: null
+      }
+    });
+    const fixture = TestBed.createComponent(AppComponent);
+    const app = fixture.componentInstance;
+    app.setTitleIfPresent(testRoute);
+    fixture.detectChanges();
+    expect(titleService.setTitle).toHaveBeenCalled();
+  });
+
+});
+
+describe('AppComponent', () => {
+  let store: Store<fromRoot.State>;
+  beforeEach(async(() => {
+    environmentMockService.getEnv$.and.returnValue(of({}));
+    idleMockService.appStateChanges.and.returnValue(of({ type: 'signout' }));
+    TestBed.configureTestingModule({
+      declarations: [
+        AppComponent,
+        HeaderComponent
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      imports: [
+        RouterTestingModule,
+        StoreModule.forRoot(
+          {
+            ...reducers,
+            userProfile: combineReducers(fromRoot.reducers)
+          })
+      ],
+      providers: [
+        {
+          provide: windowToken,
+          useValue: windowMock
+        },
+        { provide: ManageSessionServices, useValue: idleMockService },
+        { provide: EnvironmentService, useValue: environmentMockService },
         { provide: CookieService, useValue: cookieService }
       ],
     }).compileComponents();
@@ -75,7 +179,7 @@ describe('AppComponent', () => {
   let store: Store<fromRoot.State>;
   beforeEach(async(() => {
     environmentMockService.getEnv$.and.returnValue(of({}));
-    idleMockService.appStateChanges.and.returnValue(of({type: 'signout'}));
+    idleMockService.appStateChanges.and.returnValue(of({ type: 'keepalive' }));
     TestBed.configureTestingModule({
       declarations: [
         AppComponent,
@@ -95,62 +199,8 @@ describe('AppComponent', () => {
           provide: windowToken,
           useValue: windowMock
         },
-        { provide: ManageSessionServices, useValue: idleMockService},
-        { provide: EnvironmentService, useValue: environmentMockService},
-        { provide: CookieService, useValue: cookieService }
-      ],
-    }).compileComponents();
-    store = TestBed.get(Store);
-
-    spyOn(store, 'dispatch').and.callThrough();
-  }));
-
-  it('should create the app', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-
-    const app = fixture.debugElement.componentInstance;
-    fixture.detectChanges();
-    expect(app).toBeTruthy();
-  }));
-
-  it('should dispatch a logout action', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    app.onNavigate('sign-out');
-    fixture.detectChanges();
-
-    expect(store.dispatch).toHaveBeenCalledWith(new Logout());
-
-  }));
-
-});
-
-describe('AppComponent', () => {
-  let store: Store<fromRoot.State>;
-  beforeEach(async(() => {
-    environmentMockService.getEnv$.and.returnValue(of({}));
-    idleMockService.appStateChanges.and.returnValue(of({type: 'keepalive'}));
-    TestBed.configureTestingModule({
-      declarations: [
-        AppComponent,
-        HeaderComponent
-      ],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [
-        RouterTestingModule,
-        StoreModule.forRoot(
-          {
-            ...reducers,
-            userProfile: combineReducers(fromRoot.reducers)
-          })
-      ],
-      providers: [
-        {
-          provide: windowToken,
-          useValue: windowMock
-        },
-        { provide: ManageSessionServices, useValue: idleMockService},
-        { provide: EnvironmentService, useValue: environmentMockService},
+        { provide: ManageSessionServices, useValue: idleMockService },
+        { provide: EnvironmentService, useValue: environmentMockService },
         { provide: CookieService, useValue: cookieService }
       ],
     }).compileComponents();

--- a/src/app/containers/app/app.component.ts
+++ b/src/app/containers/app/app.component.ts
@@ -38,19 +38,6 @@ export class AppComponent implements OnInit {
     });
   }
 
-  public setTitleIfPresent(data: Event) {
-    if (data instanceof RoutesRecognized) {
-      let child = data.state.root;
-      do {
-        child = child.firstChild;
-      } while (child.firstChild);
-      const d = child.data;
-      if (d.title) {
-        this.titleService.setTitle(`${d.title} - HM Courts & Tribunals Service - GOV.UK`);
-      }
-    }
-  }
-
   public ngOnInit() {
     this.environmentService.getEnv$().subscribe(env => {
       if (env.oidcEnabled) {
@@ -139,4 +126,18 @@ export class AppComponent implements OnInit {
       return this.store.dispatch(new fromRoot.Logout());
     }
   }
+
+  public setTitleIfPresent(data: Event) {
+    if (data instanceof RoutesRecognized) {
+      let child = data.state.root;
+      do {
+        child = child.firstChild;
+      } while (child.firstChild);
+      const d = child.data;
+      if (d.title) {
+        this.titleService.setTitle(`${d.title} - HM Courts & Tribunals Service - GOV.UK`);
+      }
+    }
+  }
+
 }

--- a/src/app/containers/app/app.component.ts
+++ b/src/app/containers/app/app.component.ts
@@ -10,7 +10,7 @@ import * as fromRoot from '../../store';
 import { RoleService } from '@hmcts/rpx-xui-common-lib';
 import { CookieService } from 'ngx-cookie';
 import { AppUtils } from 'src/app/utils/app-utils';
-import { Router, RoutesRecognized } from '@angular/router';
+import { Event, Router, RoutesRecognized } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 
 @Component({
@@ -20,7 +20,6 @@ import { Title } from '@angular/platform-browser';
 })
 export class AppComponent implements OnInit {
 
-  public title$: Observable<string>;
   public identityBar$: Observable<string[]>;
   public modalData$: Observable<{isVisible?: boolean; countdown?: string}>;
 
@@ -35,17 +34,21 @@ export class AppComponent implements OnInit {
     private readonly titleService: Title
   ) {
     this.router.events.subscribe((data) => {
-      if (data instanceof RoutesRecognized) {
-        let child = data.state.root;
-        do {
-          child = child.firstChild;
-        } while (child.firstChild);
-        const d = child.data;
-        if (d.title) {
-          this.titleService.setTitle(`${d.title} - HM Courts & Tribunals Service - GOV.UK`);
-        }
-      }
+      this.setTitleIfPresent(data);
     });
+  }
+
+  public setTitleIfPresent(data: Event) {
+    if (data instanceof RoutesRecognized) {
+      let child = data.state.root;
+      do {
+        child = child.firstChild;
+      } while (child.firstChild);
+      const d = child.data;
+      if (d.title) {
+        this.titleService.setTitle(`${d.title} - HM Courts & Tribunals Service - GOV.UK`);
+      }
+    }
   }
 
   public ngOnInit() {
@@ -62,7 +65,6 @@ export class AppComponent implements OnInit {
     this.googleAnalyticsService.init(config.googleAnalyticsKey);
     this.modalData$ = this.store.pipe(select(fromRoot.getModalSessionData));
     // this.identityBar$ = this.store.pipe(select(fromSingleFeeAccountStore.getSingleFeeAccountData));
-    this.title$ = this.store.pipe(select(fromRoot.getAppPageTitle));
 
     this.idleStart();
     this.idleService.appStateChanges().subscribe(value => {

--- a/src/app/containers/app/app.component.ts
+++ b/src/app/containers/app/app.component.ts
@@ -10,6 +10,8 @@ import * as fromRoot from '../../store';
 import { RoleService } from '@hmcts/rpx-xui-common-lib';
 import { CookieService } from 'ngx-cookie';
 import { AppUtils } from 'src/app/utils/app-utils';
+import { Router, RoutesRecognized } from '@angular/router';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-root',
@@ -28,8 +30,23 @@ export class AppComponent implements OnInit {
     private readonly idleService: ManageSessionServices,
     private readonly environmentService: EnvironmentService,
     private readonly roleService: RoleService,
-    private readonly cookieService: CookieService
-  ) {}
+    private readonly cookieService: CookieService,
+    private readonly router: Router,
+    private readonly titleService: Title
+  ) {
+    this.router.events.subscribe((data) => {
+      if (data instanceof RoutesRecognized) {
+        let child = data.state.root;
+        do {
+          child = child.firstChild;
+        } while (child.firstChild);
+        const d = child.data;
+        if (d.title) {
+          this.titleService.setTitle(`${d.title} - HM Courts & Tribunals Service - GOV.UK`);
+        }
+      }
+    });
+  }
 
   public ngOnInit() {
     this.environmentService.getEnv$().subscribe(env => {
@@ -46,11 +63,6 @@ export class AppComponent implements OnInit {
     this.modalData$ = this.store.pipe(select(fromRoot.getModalSessionData));
     // this.identityBar$ = this.store.pipe(select(fromSingleFeeAccountStore.getSingleFeeAccountData));
     this.title$ = this.store.pipe(select(fromRoot.getAppPageTitle));
-    this.store.pipe(select(fromRoot.getRouterState)).subscribe(rootState => {
-      if (rootState) {
-        this.store.dispatch(new fromRoot.SetPageTitle(rootState.state.url));
-      }
-    });
 
     this.idleStart();
     this.idleService.appStateChanges().subscribe(value => {

--- a/src/app/store/actions/app.actions.spec.ts
+++ b/src/app/store/actions/app.actions.spec.ts
@@ -3,28 +3,6 @@ import { GlobalError } from '../reducers/app.reducer';
 
 describe('App Actions', () => {
 
-  describe('Set page title', () => {
-    it('should create an action', () => {
-      const payload = 'value';
-      const action = new fromApp.SetPageTitle(payload);
-
-      expect({ ...action }).toEqual({
-        type: fromApp.SET_PAGE_TITLE,
-        payload,
-      });
-    });
-  });
-
-  describe('Set page title Fail', () => {
-    it('should create an action', () => {
-      const action = new fromApp.SetPageTitleErrors();
-
-      expect({ ...action }).toEqual({
-        type: fromApp.SET_PAGE_TITLE_ERRORS
-      });
-    });
-  });
-
   describe('Logout', () => {
     it('should create an action', () => {
       const action = new fromApp.Logout();

--- a/src/app/store/actions/app.actions.ts
+++ b/src/app/store/actions/app.actions.ts
@@ -3,8 +3,6 @@ import { Action } from '@ngrx/store';
 
 import { UserInterface } from '../../../models/user.model';
 
-export const SET_PAGE_TITLE = '[APP] Set Page Title';
-export const SET_PAGE_TITLE_ERRORS = '[APP] Set Page Title Errors';
 export const GET_USER_DETAILS = '[User] Get User Details';
 export const GET_USER_DETAILS_SUCCESS = '[User] Get User Details Success';
 export const GET_USER_DETAILS_FAIL = '[User]Get User Details Fail';
@@ -13,20 +11,7 @@ export const APP_ADD_GLOBAL_ERROR = '[APP] Add Global Error';
 export const APP_ADD_GLOBAL_ERROR_SUCCESS = '[APP] Add Global Error Success';
 export const APP_CLEAR_GLOBAL_ERROR = '[APP] Clear Global Error';
 
-
 export const LOGOUT = '[App] Logout';
-
-export class SetPageTitle implements Action {
-  public readonly type = SET_PAGE_TITLE;
-  constructor(public payload: string) {}
-}
-/**
- * This is not used anywhere yet
- * it should be used when error displayed on the page.
- */
-export class SetPageTitleErrors implements Action {
-  public readonly type = SET_PAGE_TITLE_ERRORS;
-}
 
 export class Logout implements Action {
   public readonly type = LOGOUT;
@@ -92,8 +77,6 @@ export type appActions =
   | SignedOutSuccess
   | KeepAlive
   | SetModal
-  | SetPageTitle
-  | SetPageTitleErrors
   | Logout
   | AddGlobalError
   | ClearGlobalError

--- a/src/app/store/reducers/app.reducer.spec.ts
+++ b/src/app/store/reducers/app.reducer.spec.ts
@@ -38,28 +38,4 @@ describe('App Reducer', () => {
             expect(state).toEqual(expectedState);
         });
     });
-
-    describe('SET_PAGE_TITLE', () => {
-        it('should return state', () => {
-            const action = new fromActions.SetPageTitle('yabbadabba');
-            const state = appReducer.reducer(appReducer.initialState, action);
-            const expectedState = {
-                ...appReducer.initialState,
-                pageTitle: AppUtils.setPageTitle('yabbadabba')
-            };
-            expect(state).toEqual(expectedState);
-        });
-    });
-
-    describe('SET_PAGE_TITLE_ERRORS', () => {
-        it('should return state', () => {
-            const action = new fromActions.SetPageTitleErrors();
-            const state = appReducer.reducer(appReducer.initialState, action);
-            const expectedState = {
-                ...appReducer.initialState,
-                pageTitle: 'Error: '
-            };
-            expect(state).toEqual(expectedState);
-        });
-    });
 });

--- a/src/app/store/reducers/app.reducer.ts
+++ b/src/app/store/reducers/app.reducer.ts
@@ -1,5 +1,4 @@
 import { UserModel } from '../../../models/user.model';
-import {AppUtils} from '../../utils/app-utils';
 import * as fromAction from '../actions';
 
 

--- a/src/app/store/reducers/app.reducer.ts
+++ b/src/app/store/reducers/app.reducer.ts
@@ -42,20 +42,6 @@ export function reducer(
   action: fromAction.appActions
 ): AppState {
   switch (action.type) {
-    case fromAction.SET_PAGE_TITLE: {
-      const pageTitle = AppUtils.setPageTitle(action.payload);
-      return {
-        ...state,
-        pageTitle
-      };
-    }
-    case fromAction.SET_PAGE_TITLE_ERRORS: {
-      const pageTitle = `Error: ${state.pageTitle}`;
-      return {
-        ...state,
-        pageTitle
-      };
-    }
     case fromAction.LOGOUT: {
       return {
         ...state,

--- a/src/app/utils/app-utils.spec.ts
+++ b/src/app/utils/app-utils.spec.ts
@@ -4,34 +4,6 @@ import { User } from '@hmcts/rpx-xui-common-lib';
 
 describe('AppUtils', () => {
 
-  it('should set correct page titles pending details', () => {
-    const array = AppUtils.setPageTitle('/pending-organisations/organisation/');
-    expect(array).toEqual('Pending organisation details - Approve organisation');
-  });
-  it('should set correct page titles confirmation', () => {
-    const array = AppUtils.setPageTitle('/pending-organisations/approve');
-    expect(array).toEqual('Check details - Approve organisations');
-  });
-  it('should set correct page titles check details', () => {
-    const array = AppUtils.setPageTitle('/pending-organisations/approve-success');
-    expect(array).toEqual('Confirmation - Approve organisations');
-  });
-  it('should set correct page titles pending ', () => {
-    const array = AppUtils.setPageTitle('/pending-organisations');
-    expect(array).toEqual('Pending organisations - Approve organisations');
-  });
-  it('should set correct page titles active details', () => {
-    const array = AppUtils.setPageTitle('/organisations/organisation');
-    expect(array).toEqual('Check details - Approve organisations');
-  });
-  it('should set correct page titles active details', () => {
-    const array = AppUtils.setPageTitle('/organisations/organisation/');
-    expect(array).toEqual('Active organisation details - Approve organisations');
-  });
-  it('should set correct page titles general fallback', () => {
-    const array = AppUtils.setPageTitle('');
-    expect(array).toEqual('Active organisations - Approve organisations');
-  });
   it('should map organisation', () => {
     const orgAddress: [OrganisationAddress] = [{
       addressLine1: 'Line1',

--- a/src/app/utils/app-utils.ts
+++ b/src/app/utils/app-utils.ts
@@ -10,36 +10,6 @@ import { GlobalError } from '../store/reducers/app.reducer';
  */
 export class AppUtils {
 
-  public static setPageTitle(url): string {
-    /**
-     * it sets correct page titles
-     */
-    switch (url) {
-      case '/pending-organisations/organisation/': {
-        return 'Pending organisation details - Approve organisation';
-      }
-      case '/pending-organisations/approve' : {
-        return 'Check details - Approve organisations';
-      }
-      case '/pending-organisations/approve-success' : {
-        return 'Confirmation - Approve organisations';
-      }
-      case '/pending-organisations': {
-        return 'Pending organisations - Approve organisations';
-      }
-      case '/organisations/organisation': {
-        return 'Check details - Approve organisations';
-      }
-    }
-    // need to use undex of becaue id the id that is passed on the end.
-    if (url.indexOf('/organisations/organisation/') !== -1) {
-      return 'Active organisation details - Approve organisations';
-    }
-    // default return
-    return 'Active organisations - Approve organisations';
-
-  }
-
   public static mapOrganisations(obj: Organisation[]): OrganisationVM[] {
     const organisationModel: OrganisationVM[] = [];
     obj.forEach((apiOrg) => {

--- a/src/org-manager/org-manager.routing.ts
+++ b/src/org-manager/org-manager.routing.ts
@@ -2,7 +2,7 @@ import { ModuleWithProviders } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ApproveOrganisationSuccessComponent } from 'src/org-manager/containers/approve-organisation-success/approve-organisation-success.component';
 import { ApproveOrganisationComponent } from 'src/org-manager/containers/approve-organisation/approve-organisation.component';
-import { PendingOrganisationsComponent} from 'src/org-manager/containers/pending-organisations/pending-organisations.component';
+import { PendingOrganisationsComponent } from 'src/org-manager/containers/pending-organisations/pending-organisations.component';
 import { AuthGuard } from 'src/services/auth/auth.guard';
 import { OrganisationDetailsComponent } from './components';
 import { ActiveOrganisationsComponent } from './containers';
@@ -12,7 +12,7 @@ import { ReinviteUserComponent } from './containers/reinvite-user/reinvite-user.
 import { UserDetailsComponent } from './containers/user-details/user-details.component';
 import { UserApprovalGuard } from './guards/users-approval.guard';
 import { DeleteOrganisationComponent } from './containers/delete-organisation/delete-organisation.component';
-import {DeleteOrganisationSuccessComponent} from './containers/delete-organisation-success/delete-organisation-success.component';
+import { DeleteOrganisationSuccessComponent } from './containers/delete-organisation-success/delete-organisation-success.component';
 import { RoleGuard, RoleMatching } from '@hmcts/rpx-xui-common-lib';
 
 export const ROUTES: Routes = [
@@ -20,43 +20,69 @@ export const ROUTES: Routes = [
     path: 'organisation',
     component: PendingOrganisationsComponent,
     canActivate: [AuthGuard, RoleGuard],
-    data: {needsRole: ['prd-admin'], roleMatching: RoleMatching.ALL }
+    data: {
+      needsRole: ['prd-admin'],
+      roleMatching: RoleMatching.ALL,
+      title: 'Organisations'
+    }
   },
   {
     path: 'pending-organisations',
     component: PendingOrganisationsComponent,
     canActivate: [AuthGuard, RoleGuard],
-    data: {needsRole: ['prd-admin'], roleMatching: RoleMatching.ALL }
+    data: {
+      needsRole: ['prd-admin'],
+      roleMatching: RoleMatching.ALL,
+      title: 'Pending organisations'
+    }
   },
   {
     path: 'active-organisation',
     component: ActiveOrganisationsComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Active organisations'
+    }
   },
   {
     path: 'approve-organisations',
     component: ApproveOrganisationComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Check details'
+    }
   },
   {
     path: 'approve-organisations-success',
     component: ApproveOrganisationSuccessComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Confirmation'
+    }
   },
   {
     path: 'delete-organisation',
     component: DeleteOrganisationComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Delete organisation'
+    }
   },
   {
     path: 'delete-organisation-success',
     component: DeleteOrganisationSuccessComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Delete organisation success'
+    }
   },
   {
     path: 'organisation-details/:orgId',
     component: OrganisationDetailsComponent,
     canActivate: [AuthGuard],
+    data: {
+      title: 'Organisation details'
+    }
   },
   {
     path: 'change/:fields/:orgId',

--- a/test/accessibility/helpers/pa11yUtil.js
+++ b/test/accessibility/helpers/pa11yUtil.js
@@ -19,7 +19,7 @@ async function pa11ytest(test,actions,timeoutVal) {
     console.log("pally test with actions : " + test.test.title);
     console.log(actions);
 
-    let screenshotPath = process.env.PWD + "/" + conf.reportPath + 'assets/';
+    let screenshotPath = conf.reportPath + 'assets/';
     if (!fs.existsSync(screenshotPath)) {
         fs.mkdirSync(screenshotPath, { recursive: true });
     }

--- a/test/accessibility/helpers/pa11yUtil.js
+++ b/test/accessibility/helpers/pa11yUtil.js
@@ -19,7 +19,7 @@ async function pa11ytest(test,actions,timeoutVal) {
     console.log("pally test with actions : " + test.test.title);
     console.log(actions);
 
-    let screenshotPath = conf.reportPath + 'assets/';
+    let screenshotPath = process.env.PWD + "/" + conf.reportPath + 'assets/';
     if (!fs.existsSync(screenshotPath)) {
         fs.mkdirSync(screenshotPath, { recursive: true });
     }

--- a/test/accessibility/reporter/customReporter.js
+++ b/test/accessibility/reporter/customReporter.js
@@ -61,7 +61,7 @@ function generateReport(passCount, failCount, tests) {
     consoleReport(reportJson);
 
     let sourceReport = __dirname + '/Report.html';
-    let destDir = process.env.PWD + "/" + conf.reportPath;
+    let destDir = conf.reportPath;
     if (!fs.existsSync(destDir)) {
         fs.mkdirSync(destDir);
     }
@@ -90,7 +90,7 @@ function getTestDetails(test) {
 
 
 function copyResources() {
-    let resourceDir = process.env.PWD + "/" + conf.reportPath + 'resources/';
+    let resourceDir = conf.reportPath + 'resources/';
     let cssDir = resourceDir + 'css/';
     if (!fs.existsSync(cssDir)) {
         fs.mkdirSync(cssDir, { recursive: true });

--- a/test/accessibility/reporter/customReporter.js
+++ b/test/accessibility/reporter/customReporter.js
@@ -61,7 +61,7 @@ function generateReport(passCount, failCount, tests) {
     consoleReport(reportJson);
 
     let sourceReport = __dirname + '/Report.html';
-    let destDir = conf.reportPath;
+    let destDir = process.env.PWD + "/" + conf.reportPath;
     if (!fs.existsSync(destDir)) {
         fs.mkdirSync(destDir);
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EUI-2141


### Change description ###
Move Page Title functionality out of the ngrx Store and use the built in Angular Title service and routing. Update page titles to correspond with the page and include the GOV.UK suffix. Remove redundant tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
