### PR TITLE
fix: restore Infrastructure Jenkins library

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -53,7 +53,7 @@ properties([
     ])
 ])
 
-@Library("Infrastructure@DTSPO-30107-jenkins-agents")
+@Library("Infrastructure")
 
 import uk.gov.hmcts.contino.AppPipelineDsl
 import uk.gov.hmcts.contino.azure.KeyVault


### PR DESCRIPTION
## Summary
- Restore the shared Jenkins `Infrastructure` library reference in Approve Org.
- Reverts the active `Infrastructure@DTSPO-30107-jenkins-agents` pin in `Jenkinsfile_CNP`.
- Keeps the change scoped to pipeline-library selection only; no test, deployment, Docker, or Playwright settings changed.

## Why
The DTSPO Jenkins agents library branch currently splits static checks and container build into separate sequential top-level stages. The current `Infrastructure` library is the correct app-repo reference and preserves the combined `Static checks / Container build` parallel block while retaining the XUI agent support available from the merged infrastructure changes.

## Validation
- `git diff --check`
- `rg -n '@Library\("Infrastructure' Jenkinsfile*`

## AI assistance
- Codex assisted with repository inspection, diff analysis, implementation, and validation evidence packaging.

## Residual risk
- Jenkins stage rendering is generated by the shared library and cannot be fully proven locally; final proof is the PR Jenkins run using the combined static/container stage again.