### PR TITLE
EXUI-5089: harden Playwright session management

### DIFF
--- a/playwright_tests/api/session-capture.unit.api.test.ts
+++ b/playwright_tests/api/session-capture.unit.api.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { __test__ as sessionCapture } from '../helpers/sessionCapture';
+
+const validIdentity = {
+  userIdentifier: 'base-alias',
+  email: 'ao@example.test',
+  password: 'do-not-log-this',
+  sessionKey: 'shared-ao-account'
+};
+
+function writeStorageState(directory: string, cookies: unknown[]): string {
+  const statePath = path.join(directory, 'state.json');
+  fs.writeFileSync(statePath, JSON.stringify({ cookies, origins: [] }));
+  return statePath;
+}
+
+test.describe('AO Playwright session management', () => {
+  test('resolves aliases to the credential identity and keeps explicit partitions separate', () => {
+    expect(sessionCapture.resolveSessionIdentity(validIdentity)).toEqual(validIdentity);
+    expect(sessionCapture.resolveSessionPartitionKey()).toBeUndefined();
+    expect(sessionCapture.resolveSessionPartitionKey(' api ')).toBe('api');
+    expect(sessionCapture.normaliseSessionStorageKey('a user@example.test/api')).toBe('a-user-example.test-api');
+  });
+
+  test('rejects an auth cookie for another host and accepts a compatible unexpired cookie', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-session-'));
+    const statePath = writeStorageState(directory, [
+      { name: 'Idam.Session', domain: 'other.example.test', expires: Math.floor(Date.now() / 1000) + 300 }
+    ]);
+    expect(sessionCapture.hasUnexpiredAuthCookie(statePath, 'https://administer-orgs.aat.platform.hmcts.net/')).toBe(false);
+
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify({
+        cookies: [{ name: 'Idam.Session', domain: '.aat.platform.hmcts.net', expires: Math.floor(Date.now() / 1000) + 300 }],
+        origins: []
+      })
+    );
+    expect(sessionCapture.hasUnexpiredAuthCookie(statePath, 'https://administer-orgs.aat.platform.hmcts.net/')).toBe(true);
+  });
+
+  test('treats malformed, expired and valid state differently', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-session-'));
+    const statePath = writeStorageState(directory, [
+      { name: 'Idam.Session', domain: '.aat.platform.hmcts.net', expires: Math.floor(Date.now() / 1000) + 300 }
+    ]);
+    expect(sessionCapture.isSessionFresh(statePath, 'https://administer-orgs.aat.platform.hmcts.net/')).toBe(true);
+
+    fs.writeFileSync(statePath, '{not-json');
+    expect(sessionCapture.isSessionFresh(statePath)).toBe(false);
+  });
+
+  test('persists state atomically and leaves no temporary file after success', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-session-'));
+    const statePath = path.join(directory, 'state.json');
+    const context = { storageState: async ({ path: outputPath }: { path: string }) => fs.writeFileSync(outputPath, '{"cookies":[]}') };
+
+    await sessionCapture.persistSessionState(context as never, statePath);
+
+    expect(fs.readFileSync(statePath, 'utf8')).toBe('{"cookies":[]}');
+    expect(fs.readdirSync(directory)).toEqual(['state.json']);
+  });
+
+  test('redacts tokens and passwords from failure markers', () => {
+    expect(sessionCapture.redactSensitiveText('https://example.test/callback?access_token=abc123&x=1 password=secret')).toBe(
+      'https://example.test/callback?access_token=[REDACTED]&x=1 password=[REDACTED]'
+    );
+  });
+
+  test('rejects wrong and service-down routes before accepting an authenticated page', async () => {
+    const locator = {
+      isVisible: async () => false,
+      first: () => locator,
+      innerText: async () => 'Unexpected page'
+    };
+    const page = (url: string) => ({
+      url: () => url,
+      locator: () => locator,
+      getByRole: () => locator
+    });
+
+    expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/other') as never, 'https://example.test/target')).toBe(false);
+    expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/service-down') as never, 'https://example.test/service-down')).toBe(false);
+  });
+
+  test('waiters reuse the lock owner result and the stale budget exceeds login and auth polling', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-session-'));
+    const lockPath = path.join(directory, 'state.lock');
+    const release = await sessionCapture.acquireSessionCaptureLock(lockPath);
+    const waiting = sessionCapture.acquireSessionCaptureLock(lockPath);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    release();
+    const waitingRelease = await waiting;
+    waitingRelease();
+
+    expect(sessionCapture.SESSION_CAPTURE_LOCK_TIMEOUT_MS).toBeGreaterThan(sessionCapture.SESSION_CAPTURE_LOCK_STALE_MS);
+    expect(sessionCapture.SESSION_CAPTURE_LOCK_STALE_MS).toBeGreaterThan(45_000 + 30_000);
+  });
+});

--- a/playwright_tests/api/session-capture.unit.api.test.ts
+++ b/playwright_tests/api/session-capture.unit.api.test.ts
@@ -70,7 +70,7 @@ test.describe('AO Playwright session management', () => {
     );
   });
 
-  test('rejects wrong and service-down routes before accepting an authenticated page', async () => {
+  test('rejects wrong and unavailable routes before accepting an authenticated page', async () => {
     const locator = {
       isVisible: async () => false,
       first: () => locator,
@@ -79,11 +79,20 @@ test.describe('AO Playwright session management', () => {
     const page = (url: string) => ({
       url: () => url,
       locator: () => locator,
-      getByRole: () => locator
+      getByRole: () => locator,
+      request: {
+        get: async () => ({
+          status: () => 200,
+          text: async () => 'true'
+        })
+      }
     });
 
     expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/other') as never, 'https://example.test/target')).toBe(false);
     expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/service-down') as never, 'https://example.test/service-down')).toBe(false);
+    expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/access-denied') as never, 'https://example.test/')).toBe(false);
+    expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://other.example.test/organisation') as never, 'https://example.test/organisation')).toBe(false);
+    expect(await sessionCapture.isExpectedAuthenticatedSurface(page('https://example.test/organisation') as never, 'https://example.test/')).toBe(true);
   });
 
   test('waiters reuse the lock owner result and the stale budget exceeds login and auth polling', async () => {
@@ -98,5 +107,21 @@ test.describe('AO Playwright session management', () => {
 
     expect(sessionCapture.SESSION_CAPTURE_LOCK_TIMEOUT_MS).toBeGreaterThan(sessionCapture.SESSION_CAPTURE_LOCK_STALE_MS);
     expect(sessionCapture.SESSION_CAPTURE_LOCK_STALE_MS).toBeGreaterThan(45_000 + 30_000);
+  });
+
+  test('does not remove a lock replaced after the original owner became stale', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ao-session-'));
+    const lockPath = path.join(directory, 'state.lock');
+    const originalRelease = await sessionCapture.acquireSessionCaptureLock(lockPath);
+
+    const staleTimestamp = new Date(Date.now() - sessionCapture.SESSION_CAPTURE_LOCK_STALE_MS - 1);
+    fs.utimesSync(lockPath, staleTimestamp, staleTimestamp);
+    const replacementRelease = await sessionCapture.acquireSessionCaptureLock(lockPath);
+
+    originalRelease();
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    replacementRelease();
+    expect(fs.existsSync(lockPath)).toBe(false);
   });
 });

--- a/playwright_tests/helpers/sessionCapture.ts
+++ b/playwright_tests/helpers/sessionCapture.ts
@@ -1,4 +1,5 @@
 import { chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { config } from '../config/config';
@@ -24,6 +25,8 @@ const SESSION_DIR = process.env.PW_SESSION_DIR
   ? path.resolve(process.env.PW_SESSION_DIR)
   : path.resolve(__dirname, '../../.sessions');
 const OAUTH_CALLBACK_ROUTE_PATTERN = /\/oauth2\/callback(?:[/?#]|$)/;
+const DEFAULT_AUTHENTICATED_ROUTE_PATTERN = /^\/(?:organisation|caseworker-details)(?:\/|$)/;
+const UNAVAILABLE_ROUTE_PATTERN = /\/(?:access-denied|service-down|not-authorised|signed-out|error)(?:\/|$)/i;
 
 type UserConfig = {
   username: string;
@@ -235,17 +238,30 @@ function isLockStale(lockPath: string): boolean {
   }
 }
 
+function hasLockOwnerToken(lockPath: string, ownerToken: string): boolean {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as { ownerToken?: string };
+    return lock.ownerToken === ownerToken;
+  } catch {
+    return false;
+  }
+}
+
 async function acquireSessionCaptureLock(lockPath: string): Promise<() => void> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < SESSION_CAPTURE_LOCK_TIMEOUT_MS) {
     try {
       const fd = fs.openSync(lockPath, 'wx');
-      fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+      const ownerToken = randomUUID();
+      fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString(), ownerToken }));
 
       return () => {
         fs.closeSync(fd);
-        fs.rmSync(lockPath, { force: true });
+        // A stale owner can finish after a replacement lock is acquired.
+        if (hasLockOwnerToken(lockPath, ownerToken)) {
+          fs.rmSync(lockPath, { force: true });
+        }
       };
     } catch (error) {
       const errorCode = (error as NodeJS.ErrnoException).code;
@@ -395,9 +411,16 @@ async function isExpectedAuthenticatedSurface(page: Page, destinationUrl: string
     return false;
   }
 
+  const current = new URL(currentUrl, config.baseUrl);
+  const destination = new URL(destinationUrl, config.baseUrl);
   const currentPath = normaliseUrlPath(currentUrl);
   const destinationPath = normaliseUrlPath(destinationUrl);
-  if ((destinationPath !== '/' && currentPath !== destinationPath) || /\/(?:service-down|not-authorised|error)(?:\/|$)/i.test(currentPath)) {
+  const isExpectedDefaultRoute = DEFAULT_AUTHENTICATED_ROUTE_PATTERN.test(currentPath);
+  if (
+    current.origin !== destination.origin ||
+    UNAVAILABLE_ROUTE_PATTERN.test(currentPath) ||
+    (destinationPath === '/' ? !isExpectedDefaultRoute : currentPath !== destinationPath)
+  ) {
     return false;
   }
 

--- a/playwright_tests/helpers/sessionCapture.ts
+++ b/playwright_tests/helpers/sessionCapture.ts
@@ -4,12 +4,12 @@ import * as path from 'node:path';
 import { config } from '../config/config';
 
 const DEFAULT_SESSION_MAX_AGE_MS = 60 * 60 * 1000;
-const SESSION_CAPTURE_LOCK_TIMEOUT_MS = 120_000;
-const SESSION_CAPTURE_LOCK_STALE_MS = 120_000;
+const SESSION_CAPTURE_LOCK_TIMEOUT_MS = 180_000;
 const SESSION_CAPTURE_LOCK_RETRY_MS = 500;
 const AUTHENTICATION_TIMEOUT_MS = 30_000;
 const AUTHENTICATION_POLL_INTERVAL_MS = 500;
 const LOGIN_REDIRECT_TIMEOUT_MS = 45_000;
+const SESSION_CAPTURE_LOCK_STALE_MS = LOGIN_REDIRECT_TIMEOUT_MS + AUTHENTICATION_TIMEOUT_MS + 60_000;
 const DEFAULT_SESSION_CAPTURE_FAILURE_TTL_MS = 120_000;
 const SESSION_CAPTURE_RETRYABLE_FAILURE_PATTERNS = [
   /Session capture did not create an authenticated session/i,
@@ -34,6 +34,15 @@ type SessionCaptureOptions = {
   force?: boolean;
   partitionKey?: string;
 };
+
+export type SessionIdentity = {
+  userIdentifier: string;
+  email: string;
+  password: string;
+  sessionKey?: string;
+};
+
+export type SessionIdentityInput = string | SessionIdentity;
 
 type AuthenticationState = {
   authenticated: boolean;
@@ -86,7 +95,7 @@ function recentSessionCaptureFailureMessage(failurePath: string, now = Date.now(
 }
 
 function writeSessionCaptureFailure(failurePath: string, error: unknown): void {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = redactSensitiveText(error instanceof Error ? error.message : String(error));
 
   try {
     fs.writeFileSync(
@@ -128,40 +137,51 @@ function getUserConfig(user: string): UserConfig {
   return account;
 }
 
-function resolveSessionPartitionKey(explicitPartitionKey?: string): string | undefined {
-  const configured = explicitPartitionKey?.trim();
-  if (configured) {
-    return configured;
+function resolveSessionIdentity(input: SessionIdentityInput): SessionIdentity {
+  if (typeof input !== 'string') {
+    return input;
   }
 
-  const fromParallelIndex = process.env.TEST_PARALLEL_INDEX?.trim();
-  if (fromParallelIndex) {
-    return `parallel-${fromParallelIndex}`;
-  }
-
-  const fromWorkerIndex = process.env.TEST_WORKER_INDEX?.trim();
-  if (fromWorkerIndex) {
-    return `worker-${fromWorkerIndex}`;
-  }
-
-  return undefined;
+  const credentials = getUserConfig(input);
+  return {
+    userIdentifier: input,
+    email: credentials.username,
+    password: credentials.password
+  };
 }
 
-export function getSessionStatePath(user: string = 'base', partitionKey?: string): string {
-  const { username } = getUserConfig(user);
-  const compositeKey = partitionKey ? `${username}.${partitionKey}` : username;
+function resolveSessionPartitionKey(explicitPartitionKey?: string): string | undefined {
+  const configured = explicitPartitionKey?.trim();
+  return configured ? configured : undefined;
+}
+
+export function getSessionStatePath(user: SessionIdentityInput = 'base', partitionKey?: string): string {
+  const identity = resolveSessionIdentity(user);
+  const compositeKey = partitionKey ? `${identity.sessionKey ?? identity.email}.${partitionKey}` : identity.sessionKey ?? identity.email;
   const key = normaliseSessionStorageKey(compositeKey);
   return path.join(SESSION_DIR, `${key}.storage.json`);
 }
 
-function hasUnexpiredAuthCookie(storageStatePath: string): boolean {
+type StorageCookie = { name: string; value: string; expires?: number; domain?: string };
+
+function isCookieCompatibleWithHost(cookieDomain: string | undefined, hostName: string): boolean {
+  const normalizedDomain = cookieDomain?.replace(/^\./, '').toLowerCase();
+  const normalizedHost = hostName.toLowerCase();
+  return !!normalizedDomain && (normalizedHost === normalizedDomain || normalizedHost.endsWith(`.${normalizedDomain}`));
+}
+
+function hasUnexpiredAuthCookie(storageStatePath: string, targetUrl = config.baseUrl): boolean {
   try {
-    const state = JSON.parse(fs.readFileSync(storageStatePath, 'utf8')) as { cookies?: Array<{ name?: string; expires?: number }> };
+    const state = JSON.parse(fs.readFileSync(storageStatePath, 'utf8')) as { cookies?: StorageCookie[] };
     const cookies = state.cookies ?? [];
     const nowSeconds = Date.now() / 1000;
+    const targetHost = new URL(targetUrl).hostname;
     return cookies.some((cookie) => {
       const name = cookie.name ?? '';
       if (name !== '__auth__' && name !== 'Idam.Session' && name !== 'ao-webapp') {
+        return false;
+      }
+      if (cookie.domain && !isCookieCompatibleWithHost(cookie.domain, targetHost)) {
         return false;
       }
       if (cookie.expires === undefined || cookie.expires === -1) {
@@ -174,7 +194,7 @@ function hasUnexpiredAuthCookie(storageStatePath: string): boolean {
   }
 }
 
-function isSessionFresh(storageStatePath: string): boolean {
+function isSessionFresh(storageStatePath: string, targetUrl = config.baseUrl): boolean {
   if (!fs.existsSync(storageStatePath)) {
     return false;
   }
@@ -185,7 +205,13 @@ function isSessionFresh(storageStatePath: string): boolean {
     return false;
   }
 
-  return hasUnexpiredAuthCookie(storageStatePath);
+  return hasUnexpiredAuthCookie(storageStatePath, targetUrl);
+}
+
+function redactSensitiveText(value: string): string {
+  return value
+    .replace(/([?&](?:token|access_token|id_token|password|secret)=)[^&#\s]*/gi, '$1[REDACTED]')
+    .replace(/((?:password|token|secret)["'=:\s]+)[^,\s&}]+/gi, '$1[REDACTED]');
 }
 
 async function launchBrowserForSessionCapture(): Promise<Browser> {
@@ -359,6 +385,26 @@ async function isOnLoginOrCallbackSurface(page: Page): Promise<boolean> {
     await isLoginInputVisible(page);
 }
 
+function normaliseUrlPath(url: string): string {
+  return new URL(url, config.baseUrl).pathname.replace(/\/$/, '') || '/';
+}
+
+async function isExpectedAuthenticatedSurface(page: Page, destinationUrl: string): Promise<boolean> {
+  const currentUrl = page.url();
+  if (await isOnLoginOrCallbackSurface(page)) {
+    return false;
+  }
+
+  const currentPath = normaliseUrlPath(currentUrl);
+  const destinationPath = normaliseUrlPath(destinationUrl);
+  if ((destinationPath !== '/' && currentPath !== destinationPath) || /\/(?:service-down|not-authorised|error)(?:\/|$)/i.test(currentPath)) {
+    return false;
+  }
+
+  const bodyText = await page.locator('body').innerText().catch(() => '');
+  return bodyText.trim().length > 0 && await waitForAuthenticatedByApi(page);
+}
+
 async function waitForLoginRedirectToSettle(page: Page, timeoutMs = LOGIN_REDIRECT_TIMEOUT_MS): Promise<void> {
   const deadline = Date.now() + timeoutMs;
 
@@ -460,10 +506,16 @@ async function isAuthenticatedByApi(page: Page): Promise<boolean> {
 
 async function persistSessionState(context: BrowserContext, storageStatePath: string): Promise<void> {
   fs.mkdirSync(path.dirname(storageStatePath), { recursive: true });
-  await context.storageState({ path: storageStatePath });
+  const temporaryPath = `${storageStatePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    await context.storageState({ path: temporaryPath });
+    fs.renameSync(temporaryPath, storageStatePath);
+  } finally {
+    fs.rmSync(temporaryPath, { force: true });
+  }
 }
 
-export async function sessionCapture(user: string = 'base', options: SessionCaptureOptions = {}): Promise<string> {
+export async function sessionCapture(user: SessionIdentityInput = 'base', options: SessionCaptureOptions = {}): Promise<string> {
   const partitionKey = resolveSessionPartitionKey(options.partitionKey);
   const storageStatePath = getSessionStatePath(user, partitionKey);
   const lockPath = `${storageStatePath}.lock`;
@@ -497,9 +549,9 @@ export async function sessionCapture(user: string = 'base', options: SessionCapt
       );
     }
 
-    const { username, password } = getUserConfig(user);
+    const identity = resolveSessionIdentity(user);
     const partitionSuffix = partitionKey ? ` [${partitionKey}]` : '';
-    console.log(`[playwright-session] Capturing session for ${username}${partitionSuffix} -> ${storageStatePath}`);
+    console.log(`[playwright-session] Capturing session for ${identity.userIdentifier}${partitionSuffix} -> ${storageStatePath}`);
     let browser: Browser | undefined;
 
     try {
@@ -507,11 +559,11 @@ export async function sessionCapture(user: string = 'base', options: SessionCapt
       const context = await browser.newContext();
       const page = await context.newPage();
 
-      await completeLoginOnPage(page, username, password);
+      await completeLoginOnPage(page, identity.email, identity.password);
       const authenticated = await waitForAuthenticatedByApi(page);
       if (!authenticated) {
         throw new Error(
-          `Session capture did not create an authenticated session for "${username}". ${await loginFailureContext(page)}`
+          `Session capture did not create an authenticated session for "${identity.userIdentifier}". ${await loginFailureContext(page)}`
         );
       }
       await persistSessionState(context, storageStatePath);
@@ -526,9 +578,9 @@ export async function sessionCapture(user: string = 'base', options: SessionCapt
   });
 }
 
-export async function applySessionCookies(page: Page, user: string = 'base', options: SessionCaptureOptions = {}): Promise<void> {
-  const loadCookies = (storageStatePath: string): any[] => {
-    const state = JSON.parse(fs.readFileSync(storageStatePath, 'utf8')) as { cookies?: any[] };
+export async function applySessionCookies(page: Page, user: SessionIdentityInput = 'base', options: SessionCaptureOptions = {}): Promise<void> {
+  const loadCookies = (storageStatePath: string): StorageCookie[] => {
+    const state = JSON.parse(fs.readFileSync(storageStatePath, 'utf8')) as { cookies?: StorageCookie[] };
     return state.cookies ?? [];
   };
 
@@ -542,13 +594,12 @@ export async function applySessionCookies(page: Page, user: string = 'base', opt
 export async function ensureAuthenticatedPageAt(
   page: Page,
   destinationUrl: string,
-  user: string = 'base',
+  user: SessionIdentityInput = 'base',
   options: SessionCaptureOptions = {}
 ): Promise<void> {
   const gotoAndVerify = async (): Promise<boolean> => {
     await page.goto(destinationUrl, { waitUntil: 'domcontentloaded' });
-    const onLoginOrCallbackSurface = await isOnLoginOrCallbackSurface(page);
-    return !onLoginOrCallbackSurface && await waitForAuthenticatedByApi(page);
+    return isExpectedAuthenticatedSurface(page, destinationUrl);
   };
 
   await applySessionCookies(page, user, options);
@@ -562,9 +613,25 @@ export async function ensureAuthenticatedPageAt(
     return;
   }
 
-  throw new Error(`Unable to ensure authenticated page for user "${user}".`);
+  const identity = resolveSessionIdentity(user);
+  throw new Error(`Unable to ensure authenticated page for user "${identity.userIdentifier}".`);
 }
 
-export async function ensureAuthenticatedPage(page: Page, user: string = 'base', options: SessionCaptureOptions = {}): Promise<void> {
+export async function ensureAuthenticatedPage(page: Page, user: SessionIdentityInput = 'base', options: SessionCaptureOptions = {}): Promise<void> {
   await ensureAuthenticatedPageAt(page, config.baseUrl, user, options);
 }
+
+export const __test__ = {
+  normaliseSessionStorageKey,
+  resolveSessionIdentity,
+  resolveSessionPartitionKey,
+  redactSensitiveText,
+  hasUnexpiredAuthCookie,
+  isSessionFresh,
+  isExpectedAuthenticatedSurface,
+  acquireSessionCaptureLock,
+  persistSessionState,
+  sessionCapture,
+  SESSION_CAPTURE_LOCK_STALE_MS,
+  SESSION_CAPTURE_LOCK_TIMEOUT_MS
+};


### PR DESCRIPTION
### Jira link

See [EXUI-5089](https://tools.hmcts.net/jira/browse/EXUI-5089)

### Change description ###

- Harden AO Playwright session capture with identity-based state keys, explicit partitions, host-compatible session cookies, bounded filesystem locking, atomic state persistence and redacted failure markers.
- Reject authenticated-but-invalid readiness surfaces, including wrong routes and service-down/error pages.
- Add direct coverage for session identity, freshness, corruption, lock contention, redaction and readiness contracts.

### Testing done

Automated:

- [x] `yarn test:playwright:unit` - 73 passed.
- [x] `yarn lint:test` - passed.
- [x] `yarn exec eslint playwright_tests/helpers/sessionCapture.ts playwright_tests/api/session-capture.unit.api.test.ts` - passed.
- [x] `git diff --check` - passed.
- [ ] Not run: authenticated AO API, integration and E2E suites require live environment credentials and service access.
- [ ] Not run cleanly: repository-wide `yarn exec tsc --noEmit --pretty false` remains red on pre-existing API/test typing errors; no diagnostics were reported for changed files.

Manual:

- [ ] Live AO authenticated journey - requires target-environment credentials.

Evidence:

- HTML: N/A - direct unit runner output only.
- Odhin: N/A - direct unit runner output only.
- JUnit: N/A - direct unit runner output only.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
